### PR TITLE
Mitigate the possibility of MySQL data truncation by providing a safer length for critical columns.

### DIFF
--- a/src/pas/plugins/sqlalchemy/model.py
+++ b/src/pas/plugins/sqlalchemy/model.py
@@ -99,12 +99,12 @@ class User(Principal):
     roles = association_proxy("_roles", "name")
 
     # memberdata property sheet
-    email = Column(String(40), default=u"", index=True)
+    email = Column(String(80), default=u"", index=True)
     portal_skin = Column(String(20), default=u"")
     listed = Column(Integer, default=1)
     login_time = Column(DateTime(), default=functions.now())
     last_login_time = Column(DateTime(), default=functions.now())
-    fullname = Column(String(40), default=u"", index=True)
+    fullname = Column(String(80), default=u"", index=True)
     error_log_update = Column(Float, default=0)
     home_page = Column(String(40), default=u"")
     location = Column(String(40), default=u"")


### PR DESCRIPTION
MySQL will silently truncate larger values, and this will fatally lead to a situation where the user cannot login or reset the password, since the truncated email will always be invalid.

Companies and organizations will often have very long email addresses (e.g. gordon.freeman@anom-materials.black-mesa.gov), and 40 chars might be unsufficient. I have changed the value for both the 'email' and 'fullname' to the safer value of 80.
